### PR TITLE
Introduce an adapter option for bugs bunny

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
  - export POLLER_RMQ_PORT=$(docker inspect --format '{{ (index (index .NetworkSettings.Ports "5672/tcp") 0).HostPort }}' roger_rabbit )
  - until curl --silent -XGET --fail http://127.0.0.1:${POLLER_RMQ_PORT} &> /dev/null ; do printf '.'; sleep 1; done
 elixir:
-  - '1.7.2'
+  - '1.7.4'
 before_script:
   - "mix local.hex --force"
   - "mix local.rebar --force"

--- a/apps/bugs_bunny/lib/bugs_bunny.ex
+++ b/apps/bugs_bunny/lib/bugs_bunny.ex
@@ -1,6 +1,4 @@
 defmodule BugsBunny do
-  require Logger
-
   alias BugsBunny.Worker.RabbitConnection, as: Conn
 
   @type f :: ({:ok, AMQP.Channel.t()} | {:error, :disconected | :out_of_channels} -> any())
@@ -89,11 +87,8 @@ defmodule BugsBunny do
     do_with_conn(conn_worker, fn
       {:ok, channel} ->
         with {:ok, _} <- adapter.declare_queue(channel, queue, queue_options),
-             :ok <- Logger.info("queue: #{queue} successfully declared"),
              :ok <- adapter.declare_exchange(channel, exchange, type, exchange_options),
-             :ok <- Logger.info("exchange #{exchange} successfully declared"),
-             :ok <- adapter.queue_bind(channel, queue, exchange, bind_options),
-             :ok <- Logger.info("#{queue} successfully bound to #{exchange}") do
+             :ok <- adapter.queue_bind(channel, queue, exchange, bind_options) do
           :ok
         else
           {:error, _} = error -> error

--- a/apps/bugs_bunny/lib/bugs_bunny/clients/rabbitmq.ex
+++ b/apps/bugs_bunny/lib/bugs_bunny/clients/rabbitmq.ex
@@ -1,5 +1,8 @@
 defmodule BugsBunny.RabbitMQ do
+  require Logger
+
   @behaviour BugsBunny.Clients.Adapter
+
   use AMQP
 
   @impl true
@@ -39,7 +42,14 @@ defmodule BugsBunny.RabbitMQ do
 
   @impl true
   def declare_queue(channel, queue \\ "", options \\ []) do
-    Queue.declare(channel, queue, options)
+    case Queue.declare(channel, queue, options) do
+      {:ok, res} ->
+        Logger.info("queue: #{queue} successfully declared")
+        {:ok, res}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
   end
 
   @impl true
@@ -48,7 +58,11 @@ defmodule BugsBunny.RabbitMQ do
   def declare_exchange(_channel, "", _type, _options), do: :ok
 
   def declare_exchange(channel, exchange, type, options) do
-    Exchange.declare(channel, exchange, type, options)
+    case Exchange.declare(channel, exchange, type, options) do
+      :ok ->
+        Logger.info("exchange #{exchange} successfully declared")
+        :ok
+    end
   end
 
   @impl true
@@ -57,6 +71,10 @@ defmodule BugsBunny.RabbitMQ do
   def queue_bind(_channel, _queue, "", _options), do: :ok
 
   def queue_bind(channel, queue, exchange, options) do
-    Queue.bind(channel, queue, exchange, options)
+    case Queue.bind(channel, queue, exchange, options) do
+      :ok ->
+        Logger.info("#{queue} successfully bound to #{exchange}")
+        :ok
+    end
   end
 end

--- a/apps/bugs_bunny/lib/bugs_bunny/clients/rabbitmq.ex
+++ b/apps/bugs_bunny/lib/bugs_bunny/clients/rabbitmq.ex
@@ -62,6 +62,9 @@ defmodule BugsBunny.RabbitMQ do
       :ok ->
         Logger.info("exchange #{exchange} successfully declared")
         :ok
+
+      {:error, error} ->
+        {:error, error}
     end
   end
 
@@ -75,6 +78,9 @@ defmodule BugsBunny.RabbitMQ do
       :ok ->
         Logger.info("#{queue} successfully bound to #{exchange}")
         :ok
+
+      {:error, error} ->
+        {:error, error}
     end
   end
 end

--- a/apps/bugs_bunny/lib/bugs_bunny/worker/rabbit_connection.ex
+++ b/apps/bugs_bunny/lib/bugs_bunny/worker/rabbit_connection.ex
@@ -19,7 +19,11 @@ defmodule BugsBunny.Worker.RabbitConnection do
             config: config()
           }
 
-    defstruct adapter: BugsBunny.RabbitMQ, connection: nil, channels: [], config: nil, monitors: []
+    defstruct adapter: BugsBunny.RabbitMQ,
+              connection: nil,
+              channels: [],
+              config: nil,
+              monitors: []
   end
 
   ##############
@@ -159,11 +163,11 @@ defmodule BugsBunny.Worker.RabbitConnection do
         num_channels = Keyword.get(config, :channels, @default_channels)
 
         channels =
-        for _ <- 1..num_channels do
-          {:ok, channel} = start_channel(adapter, connection)
+          for _ <- 1..num_channels do
+            {:ok, channel} = start_channel(adapter, connection)
 
-          channel
-        end
+            channel
+          end
 
         {:noreply, %State{state | connection: connection, channels: channels}}
     end

--- a/apps/bugs_bunny/test/integration/api_test.exs
+++ b/apps/bugs_bunny/test/integration/api_test.exs
@@ -17,7 +17,7 @@ defmodule BugsBunny.Integration.ApiTest do
       # fire and forget queue
       queue: "",
       exchange: "",
-      client: RabbitMQ
+      adapter: RabbitMQ
     ]
 
     rabbitmq_conn_pool = [
@@ -166,7 +166,6 @@ defmodule BugsBunny.Integration.ApiTest do
                queue_options: [auto_delete: true],
                exchange_options: [auto_delete: true]
              )
-
     BugsBunny.with_channel(pool_id, fn {:ok, channel} ->
       assert :ok = AMQP.Basic.publish(channel, "", "test2_queue", "Hello, World!")
       assert {:ok, "Hello, World!", _meta} = AMQP.Basic.get(channel, "test2_queue")

--- a/apps/bugs_bunny/test/integration/api_test.exs
+++ b/apps/bugs_bunny/test/integration/api_test.exs
@@ -166,6 +166,7 @@ defmodule BugsBunny.Integration.ApiTest do
                queue_options: [auto_delete: true],
                exchange_options: [auto_delete: true]
              )
+
     BugsBunny.with_channel(pool_id, fn {:ok, channel} ->
       assert :ok = AMQP.Basic.publish(channel, "", "test2_queue", "Hello, World!")
       assert {:ok, "Hello, World!", _meta} = AMQP.Basic.get(channel, "test2_queue")

--- a/apps/bugs_bunny/test/integration/rabbit_connection_test.exs
+++ b/apps/bugs_bunny/test/integration/rabbit_connection_test.exs
@@ -14,7 +14,7 @@ defmodule BugsBunny.Integration.RabbitConnectionTest do
       port: String.to_integer(System.get_env("POLLER_RMQ_PORT") || "5672"),
       queue: "test.queue",
       exchange: "",
-      client: RabbitMQ
+      adapter: RabbitMQ
     ]
 
     {:ok, config: rabbitmq_config}

--- a/apps/bugs_bunny/test/worker/rabbit_connection_test.exs
+++ b/apps/bugs_bunny/test/worker/rabbit_connection_test.exs
@@ -12,7 +12,7 @@ defmodule BugsBunny.Worker.RabbitConnectionTest do
       port: String.to_integer(System.get_env("POLLER_RMQ_PORT") || "5672"),
       queue: "test.queue",
       exchange: "",
-      client: FakeRabbitMQ
+      adapter: FakeRabbitMQ
     ]
 
     {:ok, config: rabbitmq_config}

--- a/apps/domain/test/tasks/runners/docker_build_test.exs
+++ b/apps/domain/test/tasks/runners/docker_build_test.exs
@@ -35,7 +35,12 @@ defmodule Domain.Tasks.Runners.DockerBuildTest do
       :ok
     end)
     |> stub(:push_image, fn docker_image_repo, tag, credentials ->
-      assert credentials == %{docker_password: nil, docker_servername: nil, docker_username: "pepe"}
+      assert credentials == %{
+               docker_password: nil,
+               docker_servername: nil,
+               docker_username: "pepe"
+             }
+
       assert tag == "v1.0.0"
       assert docker_image_repo == "pepe/test"
       :ok
@@ -65,7 +70,12 @@ defmodule Domain.Tasks.Runners.DockerBuildTest do
       :ok
     end)
     |> stub(:push_image, fn docker_image_repo, tag, credentials ->
-      assert credentials == %{docker_password: nil, docker_servername: nil, docker_username: "pepe"}
+      assert credentials == %{
+               docker_password: nil,
+               docker_servername: nil,
+               docker_username: "pepe"
+             }
+
       assert tag == "v2.0.0"
       assert docker_image_repo == "pepe/test2"
       :ok

--- a/apps/repo_jobs/lib/repo_jobs/config.ex
+++ b/apps/repo_jobs/lib/repo_jobs/config.ex
@@ -32,7 +32,7 @@ defmodule RepoJobs.Config do
 
   def get_rabbitmq_client() do
     get_rabbitmq_config()
-    |> Keyword.get(:client, BugsBunny.RabbitMQ)
+    |> Keyword.get(:adapter, BugsBunny.RabbitMQ)
   end
 
   def get_rabbitmq_reconnection_interval() do

--- a/apps/repo_jobs/test/consumer_test.exs
+++ b/apps/repo_jobs/test/consumer_test.exs
@@ -1,5 +1,6 @@
 defmodule RepoJobs.ConsumerTest do
-  use ExUnit.Case, async: true
+  # async: false to appease the ExUnit.CaptureLog
+  use ExUnit.Case, async: false
 
   import ExUnit.CaptureLog
 

--- a/apps/repo_jobs/test/consumer_test.exs
+++ b/apps/repo_jobs/test/consumer_test.exs
@@ -17,7 +17,7 @@ defmodule RepoJobs.ConsumerTest do
       port: String.to_integer(System.get_env("POLLER_RMQ_PORT") || "5672"),
       queue: "test.queue",
       exchange: "",
-      client: FakeRabbitMQ,
+      adapter: FakeRabbitMQ,
       caller: caller,
       reconnect: 10
     ]

--- a/apps/repo_jobs/test/integration/consumer_test.exs
+++ b/apps/repo_jobs/test/integration/consumer_test.exs
@@ -43,7 +43,7 @@ defmodule RepoJobs.Integration.ConsumerTest do
       port: String.to_integer(System.get_env("POLLER_RMQ_PORT") || "5672"),
       queue: @queue,
       exchange: "",
-      client: RabbitMQ
+      adapter: RabbitMQ
     ]
 
     rabbitmq_conn_pool = [

--- a/apps/repo_poller/lib/repo_poller/config.ex
+++ b/apps/repo_poller/lib/repo_poller/config.ex
@@ -32,7 +32,7 @@ defmodule RepoPoller.Config do
 
   def get_rabbitmq_client() do
     get_rabbitmq_config()
-    |> Keyword.get(:client, BugsBunny.RabbitMQ)
+    |> Keyword.get(:adapter, BugsBunny.RabbitMQ)
   end
 
   def get_rabbitmq_reconnection_interval() do

--- a/apps/repo_poller/lib/repo_poller/poller_supervisor.ex
+++ b/apps/repo_poller/lib/repo_poller/poller_supervisor.ex
@@ -32,16 +32,8 @@ defmodule RepoPoller.PollerSupervisor do
         adapter: adapter,
         github_token: token
       }) do
-    pool_id = Config.get_connection_pool_id()
-    repo = Repo.new(url, interval * 1000, adapter, token)
-
-    adapter = setup_adapter(adapter)
-
-    DynamicSupervisor.start_child(__MODULE__, %{
-      id: "poller_#{repo.name}",
-      start: {Poller, :start_link, [{repo, adapter, pool_id}]},
-      restart: :transient
-    })
+    Repo.new(url, interval * 1000, adapter, token)
+    |> start_child()
   end
 
   def stop_child(repository_url) do

--- a/apps/repo_poller/lib/repo_poller/setup_queue_worker.ex
+++ b/apps/repo_poller/lib/repo_poller/setup_queue_worker.ex
@@ -13,10 +13,11 @@ defmodule RepoPoller.SetupQueueWorker do
     queue = Config.get_rabbitmq_queue()
     exchange = Config.get_rabbitmq_exchange()
 
-    :ok = BugsBunny.create_queue_with_bind(client, pool_id, queue, exchange, :direct,
-      queue_options: [durable: true],
-      exchange_options: [durable: true]
-    )
+    :ok =
+      BugsBunny.create_queue_with_bind(client, pool_id, queue, exchange, :direct,
+        queue_options: [durable: true],
+        exchange_options: [durable: true]
+      )
 
     {:ok, :ignore}
   end

--- a/apps/repo_poller/lib/repo_poller/setup_queue_worker.ex
+++ b/apps/repo_poller/lib/repo_poller/setup_queue_worker.ex
@@ -13,7 +13,7 @@ defmodule RepoPoller.SetupQueueWorker do
     queue = Config.get_rabbitmq_queue()
     exchange = Config.get_rabbitmq_exchange()
 
-    BugsBunny.create_queue_with_bind(client, pool_id, queue, exchange, :direct,
+    :ok = BugsBunny.create_queue_with_bind(client, pool_id, queue, exchange, :direct,
       queue_options: [durable: true],
       exchange_options: [durable: true]
     )

--- a/apps/repo_poller/lib/repo_poller/setup_worker.ex
+++ b/apps/repo_poller/lib/repo_poller/setup_worker.ex
@@ -24,7 +24,8 @@ defmodule RepoPoller.SetupWorker do
       {:error, :nodedown} ->
         reconnect = Config.get_database_reconnection_interval()
         Logger.info("database node is down re-scheduling setup in #{reconnect} ms")
-        re_schedule_after_init(reconnect)
+        # TODO: use backoff for reconnections
+        Process.send_after(self(), :after_init, reconnect)
         {:noreply, state}
 
       {:error, reason} ->
@@ -47,10 +48,5 @@ defmodule RepoPoller.SetupWorker do
       {:error, _} = error ->
         error
     end
-  end
-
-  defp re_schedule_after_init(interval) do
-    # TODO: use backoff for reconnections
-    Process.send_after(self(), :after_init, interval)
   end
 end

--- a/apps/repo_poller/mix.exs
+++ b/apps/repo_poller/mix.exs
@@ -33,6 +33,7 @@ defmodule RepoPoller.MixProject do
       {:domain, in_umbrella: true},
       {:poison, "~> 4.0"},
       {:httpoison, "~> 1.3.0", override: true},
+      {:meck, "0.8.13", override: true, only: :test},
       {:mox, "~> 0.4", only: :test}
       # {:dep_from_hexpm, "~> 0.3.0"},
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"},

--- a/apps/repo_poller/test/integration/setup_queue_worker_test.exs
+++ b/apps/repo_poller/test/integration/setup_queue_worker_test.exs
@@ -46,6 +46,7 @@ defmodule RepoPoller.SetupQueueWorkerTest do
 
   test "declare queue on startup", %{pool_id: pool_id} do
     _worker_pid = start_supervised!(SetupQueueWorker)
+
     BugsBunny.with_channel(pool_id, fn {:ok, channel} ->
       assert :ok = AMQP.Basic.publish(channel, "my_exchange", "", "Hello, World!")
       assert {:ok, "Hello, World!", _meta} = AMQP.Basic.get(channel, @queue)

--- a/apps/repo_poller/test/poller_test.exs
+++ b/apps/repo_poller/test/poller_test.exs
@@ -226,7 +226,6 @@ defmodule RepoPoller.PollerTest do
              assert_receive {:error, :rate_limit, retry}
              assert_receive {:error, :rate_limit, ^retry}
            end) =~ "rate limit reached for repo: rate-limit/fake retrying in 50 ms"
-    :timer.sleep 200
   end
 
   test "handles errors when polling fails due to a custom error", %{pool_id: pool_id} do

--- a/apps/repo_poller/test/poller_test.exs
+++ b/apps/repo_poller/test/poller_test.exs
@@ -226,6 +226,7 @@ defmodule RepoPoller.PollerTest do
              assert_receive {:error, :rate_limit, retry}
              assert_receive {:error, :rate_limit, ^retry}
            end) =~ "rate limit reached for repo: rate-limit/fake retrying in 50 ms"
+    :timer.sleep 200
   end
 
   test "handles errors when polling fails due to a custom error", %{pool_id: pool_id} do

--- a/apps/repo_poller/test/poller_test.exs
+++ b/apps/repo_poller/test/poller_test.exs
@@ -26,7 +26,7 @@ defmodule RepoPoller.PollerTest do
       port: String.to_integer(System.get_env("POLLER_RMQ_PORT") || "5672"),
       queue: "new_releases.queue",
       exchange: "",
-      client: FakeRabbitMQ,
+      adapter: FakeRabbitMQ,
       caller: caller,
       reconnect: 10
     ]

--- a/apps/repo_poller/test/setup_worker_test.exs
+++ b/apps/repo_poller/test/setup_worker_test.exs
@@ -105,7 +105,7 @@ defmodule RepoPoller.SetupWorkerTest do
              wait_for(fn ->
                %{workers: num} = DynamicSupervisor.count_children(PollerSupervisor)
                num == 1
-               :timer.sleep 200
+               :timer.sleep(200)
              end)
 
     worker_pid = Process.whereis(:f@k3)

--- a/apps/repo_poller/test/setup_worker_test.exs
+++ b/apps/repo_poller/test/setup_worker_test.exs
@@ -1,5 +1,5 @@
 defmodule RepoPoller.SetupWorkerTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   import Mox
 
   alias RepoPoller.{SetupWorker, PollerSupervisor, Poller}
@@ -74,7 +74,6 @@ defmodule RepoPoller.SetupWorkerTest do
              end)
 
     worker_pid = Process.whereis(:f@k3)
-    :timer.sleep 200
     assert worker_pid
     assert %{repo: %{url: "https://github.com/no-tags/f@k3"}} = Poller.state(worker_pid)
   end

--- a/apps/repo_poller/test/setup_worker_test.exs
+++ b/apps/repo_poller/test/setup_worker_test.exs
@@ -74,6 +74,7 @@ defmodule RepoPoller.SetupWorkerTest do
              end)
 
     worker_pid = Process.whereis(:f@k3)
+    :timer.sleep 200
     assert worker_pid
     assert %{repo: %{url: "https://github.com/no-tags/f@k3"}} = Poller.state(worker_pid)
   end
@@ -105,6 +106,7 @@ defmodule RepoPoller.SetupWorkerTest do
              wait_for(fn ->
                %{workers: num} = DynamicSupervisor.count_children(PollerSupervisor)
                num == 1
+               :timer.sleep 200
              end)
 
     worker_pid = Process.whereis(:f@k3)

--- a/mix.lock
+++ b/mix.lock
@@ -17,7 +17,7 @@
   "jason": {:hex, :jason, "1.1.1", "d3ccb840dfb06f2f90a6d335b536dd074db748b3e7f5b11ab61d239506585eb2", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
   "jsx": {:hex, :jsx, "2.8.2", "7acc7d785b5abe8a6e9adbde926a24e481f29956dd8b4df49e3e4e7bcc92a018", [:mix, :rebar3], [], "hexpm"},
   "lager": {:hex, :lager, "3.6.3", "fe78951d174616273f87f0dbc3374d1430b1952e5efc4e1c995592d30a207294", [:rebar3], [{:goldrush, "0.1.9", [hex: :goldrush, repo: "hexpm", optional: false]}], "hexpm"},
-  "meck": {:hex, :meck, "0.8.12", "1f7b1a9f5d12c511848fec26bbefd09a21e1432eadb8982d9a8aceb9891a3cf2", [:rebar3], [], "hexpm"},
+  "meck": {:hex, :meck, "0.8.13", "ffedb39f99b0b99703b8601c6f17c7f76313ee12de6b646e671e3188401f7866", [:rebar3], [], "hexpm"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm"},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], [], "hexpm"},
   "mimic": {:hex, :mimic, "0.2.0", "66601fa5ce58db59e88fa0bef9d35d8169f11afcc3c8f0c77f911093f4469785", [:mix], [], "hexpm"},


### PR DESCRIPTION
During the initialization of bugs bunny I split out the AMQP related configs from ours; I pull out the adapter (previously called "client", which is a loaded term) and store it in the state. There is no need to pull this from the environment and it is a lot cleaner as pulling it out of the state is a simple pattern match.

I had to fiddle with the tests and the test setup to get them to pass on my system. We might have some timing issues.